### PR TITLE
change get.mcs method to getMcsAsNewContainerUIT

### DIFF
--- a/rcdk/R/smsd.R
+++ b/rcdk/R/smsd.R
@@ -9,7 +9,7 @@ get.mcs <- function(mol1, mol2, as.molecule = TRUE) {
   if (as.molecule) {
     return(.jcall("org.guha.rcdk.util.Misc",
            "Lorg/openscience/cdk/interfaces/IAtomContainer;",
-           "getMcsAsNewContainer", mol1, mol2))
+           "getMcsAsNewContainerUIT", mol1, mol2))
   } else {
     arr <- .jcall("org.guha.rcdk.util.Misc",
            "[[I",


### PR DESCRIPTION
solves issue #105 

@zachcp getMcsAsNewContainerUIT is a method in  cdkr/rcdkjar/src/org/guha/rcdk/util/Misc.java 

FYI I tested get.mcs using this [example](https://sourceforge.net/p/cdk/mailman/cdk-devel/thread/AANLkTinTraJZPVKuPf8dqOvG3iiWACSsXHO45Lu1qncm@mail.gmail.com/) and got:

<img width="851" alt="Screenshot 2020-03-15 at 20 49 21" src="https://user-images.githubusercontent.com/25338941/76709397-a8ec3480-66fe-11ea-83c9-d5b3571ee514.png">

Is the fact mcs12 != mcs21 a CDK-side issue?