### PR TITLE
Ghactions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,6 +41,15 @@ jobs:
         
       - uses: r-lib/actions/setup-r@v1
       
+      - uses: r-lib/actions/setup-pandoc@v1
+      - name: Cache R packages
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+
+
       - name: Install
         run: devtools::install("rcdk")
         shell: Rscript {0}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -34,7 +34,7 @@ jobs:
           
       - name: Install dependencies
         run: |
-          install.packages(c("remotes", "rcmdcheck"), repos = "http://cran.us.r-project.org")
+          install.packages(c("remotes", "rcmdcheck", "pkgdown"), repos = "http://cran.us.r-project.org")
           remotes::install_deps("rcdk", dependencies = TRUE)
         shell: Rscript {0}
         
@@ -48,4 +48,9 @@ jobs:
         run: rcmdcheck::rcmdcheck("rcdk", args = "--no-manual", error_on = "error")
         shell: Rscript {0}
         
+      - name: Deploy Website
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
+          Rscript -e 'pkgdown::deploy_to_branch(pkg="rcdk", branch="gh-pages", new_process = FALSE)'
         

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -5,12 +5,10 @@ on:
     branches:
       - main
       - master
-      - ghactions
   pull_request:
     branches:
       - main
       - master
-      - ghactions
 
 name: R-CMD-check
 
@@ -42,6 +40,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v1
       
       - uses: r-lib/actions/setup-pandoc@v1
+      
       - name: Cache R packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -34,7 +34,8 @@ jobs:
           
       - name: Install dependencies
         run: |
-          install.packages(c("remotes", "rcmdcheck", "pkgdown"), repos = "http://cran.us.r-project.org")
+          install.packages(c("remotes", "rcmdcheck"), repos = "http://cran.us.r-project.org")
+          install.packages("pkgdown", type = "binary", repos = "http://cran.us.r-project.org")
           remotes::install_deps("rcdk", dependencies = TRUE)
         shell: Rscript {0}
         


### PR DESCRIPTION
- Added pkgdown build to create a GH pages site.  
- Example site [here](https://zachcp.github.io/cdkr/).
- To activate this on the base repo to need to go to settings
  - activate pages on the `gh-pages` branch on the `/` option.

Once the PR is accepted and the settings are on, the site will build.




