### PR TITLE
Prepare for J17

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - master
+      - j17
   pull_request:
     branches:
       - main
       - master
+      - j17
 
 name: R-CMD-check
 
@@ -19,10 +21,10 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 17
           
       - name: Build with Ant
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,9 +20,13 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
+    
       - uses: actions/checkout@v2
-      - uses: r-lib/actions/setup-pandoc@v1
 
+      - uses: r-lib/actions/setup-r@v1
+      
+      - uses: r-lib/actions/setup-pandoc@v1
+      
       - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
@@ -40,10 +44,6 @@ jobs:
           install.packages("pkgdown", type = "binary", repos = "http://cran.us.r-project.org")
           remotes::install_deps("rcdk", dependencies = TRUE)
         shell: Rscript {0}
-        
-      - uses: r-lib/actions/setup-r@v1
-      
-      - uses: r-lib/actions/setup-pandoc@v1
       
       - name: Cache R packages
         uses: actions/cache@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -21,6 +21,8 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
+      - uses: r-lib/actions/setup-pandoc@v1
+
       - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:

--- a/rcdk/CHANGELOG
+++ b/rcdk/CHANGELOG
@@ -1,3 +1,8 @@
+2021-10-14
+   * Fix code to handle changes to JDK17. Notably, I needed to reduce the use of the J notation in a nubmer of places in favor of direct calls.
+   * formally deprecated `do.typing` in favor of `set.atom.types`
+   
+   
 2020-12-21 Rajarshi Guha
 
   * Updated handling of atomic descriptors to resolve a name mismatch bug

--- a/rcdk/DESCRIPTION
+++ b/rcdk/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rcdk
-Version: 3.5.3.2
+Version: 3.5.4
 Date: 2021-03-21
 Title: Interface to the 'CDK' Libraries
 Authors@R: c(person('Rajarshi', 'Guha', role=c('aut',"cph"), email='rajarshi.guha@gmail.com'),
@@ -28,6 +28,6 @@ Description: Allows the user to access functionality in the
     'CDK', a Java framework for chemoinformatics. This allows the user to load
     molecules, evaluate fingerprints, calculate molecular descriptors and so on.
     In addition, the 'CDK' API allows the user to view structures in 2D.
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 VignetteBuilder: knitr
 Encoding: UTF-8

--- a/rcdk/DESCRIPTION
+++ b/rcdk/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rcdk
-Version: 3.5.4
-Date: 2021-03-21
+Version: 3.6.0
+Date: 2021-10-14
 Title: Interface to the 'CDK' Libraries
 Authors@R: c(person('Rajarshi', 'Guha', role=c('aut',"cph"), email='rajarshi.guha@gmail.com'),
              person('Zachary', 'Charlop-Powers', role=c('cre'), email='zach.charlop.powers@gmail.com'),

--- a/rcdk/R/atoms.R
+++ b/rcdk/R/atoms.R
@@ -82,8 +82,15 @@ NULL
 #' @export
 #' @author Rajarshi Guha (\email{rajarshi.guha@@gmail.com})
 set.atom.types <- function(mol) {
-  acm <- J("org.openscience.cdk.tools.manipulator.AtomContainerManipulator")
-  acm$percieveAtomTypesAndConfigureAtoms(mol)  
+  
+    if (!.check.class(mol, "org/openscience/cdk/interfaces/IAtomContainer"))
+      stop("molecule must be of class IAtomContainer")
+    
+    .jcall("org.openscience.cdk.tools.manipulator.AtomContainerManipulator",
+           "V", "percieveAtomTypesAndConfigureAtoms", mol)
+    
+  # acm <- J("org.openscience.cdk.tools.manipulator.AtomContainerManipulator")
+  # acm$percieveAtomTypesAndConfigureAtoms(mol)  
 }
 
 #' @name get.point3d

--- a/rcdk/R/fingerprint.R
+++ b/rcdk/R/fingerprint.R
@@ -159,7 +159,14 @@ get.fingerprint <- function(molecule, type = 'standard', fp.mode = 'bit', depth=
     keyIter <- .jcall(keySet, "Ljava/util/Iterator;", method="iterator")
     keys <- list()
     for (i in 1:size) {
-      keys[[i]] <- J(keyIter, "next")
+      #keys[[i]] <- J(keyIter, "next")
+      tempkey <- .jcall(keyIter, "Ljava/lang/Object;", method="next")
+
+      if ('jobjRef' %in% class(tempkey))  {
+        tempkey <- .jsimplify(tempkey)
+      }
+      keys[[i]] <- tempkey
+    
     }
 
     values <- list()

--- a/rcdk/R/fingerprint.R
+++ b/rcdk/R/fingerprint.R
@@ -159,7 +159,7 @@ get.fingerprint <- function(molecule, type = 'standard', fp.mode = 'bit', depth=
     keyIter <- .jcall(keySet, "Ljava/util/Iterator;", method="iterator")
     keys <- list()
     for (i in 1:size) {
-      #keys[[i]] <- J(keyIter, "next")
+
       tempkey <- .jcall(keyIter, "Ljava/lang/Object;", method="next")
 
       if ('jobjRef' %in% class(tempkey))  {

--- a/rcdk/R/props.R
+++ b/rcdk/R/props.R
@@ -120,8 +120,17 @@ get.properties <- function(molecule) {
   keyIter <- .jcall(keySet, "Ljava/util/Iterator;", method="iterator")
   keys <- list()
   for (i in 1:size) {
-    ##    keys[[i]] <-.jcall(keyIter, "Ljava/lang/Object;", method="next")
-    keys[[i]] <- J(keyIter, "next")
+    # keys[[i]] <- J(keyIter, "next")
+    # keys[[i]] <-.jcall(keyIter, "Ljava/lang/Object;", method="next")
+
+    tempkey <- .jcall(keyIter, "Ljava/lang/Object;", method="next")
+
+    if ('jobjRef' %in% class(tempkey))  {
+      tempkey <- .jsimplify(tempkey)
+    }
+    
+    keys[[i]] <- tempkey
+  
   }
 
   

--- a/rcdk/R/props.R
+++ b/rcdk/R/props.R
@@ -120,9 +120,7 @@ get.properties <- function(molecule) {
   keyIter <- .jcall(keySet, "Ljava/util/Iterator;", method="iterator")
   keys <- list()
   for (i in 1:size) {
-    # keys[[i]] <- J(keyIter, "next")
-    # keys[[i]] <-.jcall(keyIter, "Ljava/lang/Object;", method="next")
-
+    
     tempkey <- .jcall(keyIter, "Ljava/lang/Object;", method="next")
 
     if ('jobjRef' %in% class(tempkey))  {

--- a/rcdk/R/rcdk.R
+++ b/rcdk/R/rcdk.R
@@ -10,11 +10,11 @@
 #' a builder object when directly working with the CDK API via
 #' `rJava`.
 #' 
-#' This method returns an instance of the \href{http://cdk.github.io/cdk/2.2/docs/api/org/openscience/cdk/silent/SilentChemObjectBuilder.html}{SilentChemObjectBuilder}. 
+#' This method returns an instance of the \href{https://cdk.github.io/cdk/2.5/docs/api/org/openscience/cdk/silent/SilentChemObjectBuilder.html}{SilentChemObjectBuilder}. 
 #' Note that this is a static object that is created at package load time, 
 #' and the same instance is returned whenever this function is called.
 #' 
-#' @return An instance of \href{http://cdk.github.io/cdk/2.3/docs/api/org/openscience/cdk/silent/SilentChemObjectBuilder.html}{SilentChemObjectBuilder}
+#' @return An instance of \href{https://cdk.github.io/cdk/2.5/docs/api/org/openscience/cdk/silent/SilentChemObjectBuilder.html}{SilentChemObjectBuilder}
 #' @export
 #' @author Rajarshi Guha (\email{rajarshi.guha@@gmail.com})
 get.chem.object.builder <- function() {

--- a/rcdk/R/smiles.R
+++ b/rcdk/R/smiles.R
@@ -2,7 +2,7 @@
 #'
 #' The CDK supports a variety of customizations for SMILES generation including
 #' the use of lower case symbols for aromatic compounds to the use of the ChemAxon
-#' \href{http://www.chemeddl.org/tools/marvin/help/formats/cxsmiles-doc.html}{CxSmiles}
+#' \href{http://butane.chem.uiuc.edu/jsmoore/marvin/help/formats/cxsmiles-doc.html}{CxSmiles}
 #' format. Each 'flavor' is represented by an integer and multiple
 #' customizations are bitwise OR'ed. This method accepts the names of one or
 #' more customizations and returns the bitwise OR of them.

--- a/rcdk/cran-comments.md
+++ b/rcdk/cran-comments.md
@@ -1,27 +1,36 @@
+## Sumbission
+rCDK v 3.6.0
+
 ## Test environments
-* local OS X install, R 3.4.2
-* ubuntu 12.04 (on travis-ci), R 3.4.2
-* win-builder (devel and release)
+* local OS X install, R 4.1
+* Ubuntu Linux 20.04.1 LTS, R-release, GCC
+* win-builder (release)
 
 ## R CMD check results
 
 0 errors | 0 warnings | 0 note
 
-* This is a new release.
 
 ## Reverse dependencies
 
-enviGCMS, iqspr, RxnSim, SimuChemPC
+chemmodlab, DeepPINCS, BioMedR, MetaDBparse, Rcpi, RxnSim, RMassBank, webchem
 
 ---
 
-* I have run R CMD check on the NUMBER downstream dependencies.
- enviGCMS: no Notes for CDK/rCDK
- iqspr: no Notes for CDK/rCDK
- RxnSim: no Notes for CDK/rCDK
- SimuChemPC: no Notes for CDK/rCDK
-  
+```
+
+✓ chemmodlab 1.1.0                       ── E: 0     | W: 0     | N: 0  
+✓ DeepPINCS 1.0.2                        ── E: 2     | W: 0     | N: 3  
+✓ BioMedR 1.2.1                          ── E: 0     | W: 0     | N: 0  
+✓ MetaDBparse 2.0.0                      ── E: 0     | W: 0     | N: 1  
+✓ Rcpi 1.28.0                            ── E: 0     | W: 0     | N: 3  
+✓ RxnSim 1.0.3                           ── E: 0     | W: 0     | N: 0  
+x RMassBank 3.2.0                        ── E: 0     | W: 7  +1 | N: 5  
+✓ webchem 1.1.1                          ── E: 0     | W: 0     | N: 0  
+OK: 7           
+```
+ 
   
 * FAILURE SUMMARY
 
-* All revdep maintainers were notified of the release on October29.
+* All revdep maintainers were notified of the release on October14.

--- a/rcdk/man/get.chem.object.builder.Rd
+++ b/rcdk/man/get.chem.object.builder.Rd
@@ -7,7 +7,7 @@
 get.chem.object.builder()
 }
 \value{
-An instance of \href{http://cdk.github.io/cdk/2.3/docs/api/org/openscience/cdk/silent/SilentChemObjectBuilder.html}{SilentChemObjectBuilder}
+An instance of \href{https://cdk.github.io/cdk/2.5/docs/api/org/openscience/cdk/silent/SilentChemObjectBuilder.html}{SilentChemObjectBuilder}
 }
 \description{
 The CDK employs a builder design pattern to construct
@@ -19,7 +19,7 @@ a builder object when directly working with the CDK API via
 `rJava`.
 }
 \details{
-This method returns an instance of the \href{http://cdk.github.io/cdk/2.2/docs/api/org/openscience/cdk/silent/SilentChemObjectBuilder.html}{SilentChemObjectBuilder}. 
+This method returns an instance of the \href{https://cdk.github.io/cdk/2.5/docs/api/org/openscience/cdk/silent/SilentChemObjectBuilder.html}{SilentChemObjectBuilder}. 
 Note that this is a static object that is created at package load time, 
 and the same instance is returned whenever this function is called.
 }

--- a/rcdk/man/smiles.flavors.Rd
+++ b/rcdk/man/smiles.flavors.Rd
@@ -46,7 +46,7 @@ A numeric representing the bitwise `OR`` of the specified flavors
 \description{
 The CDK supports a variety of customizations for SMILES generation including
 the use of lower case symbols for aromatic compounds to the use of the ChemAxon
-\href{http://www.chemeddl.org/tools/marvin/help/formats/cxsmiles-doc.html}{CxSmiles}
+\href{http://butane.chem.uiuc.edu/jsmoore/marvin/help/formats/cxsmiles-doc.html}{CxSmiles}
 format. Each 'flavor' is represented by an integer and multiple
 customizations are bitwise OR'ed. This method accepts the names of one or
 more customizations and returns the bitwise OR of them.

--- a/rcdk/vignettes/molform.Rmd
+++ b/rcdk/vignettes/molform.Rmd
@@ -92,7 +92,7 @@ mfSet
 ```
 It is important to know if an elemental formula is valid. The method `isvalid.formula`
 provides this function. Two constraints can be applied, the
-[nitrogen rule](https://en.wikipedia.org/wiki/Nitrogen_rule) and the  [RDBE rule](http://fiehnlab.ucdavis.edu/projects/seven-golden-rules/ring-double-bonds) (Ring Double Bond Equivalent).
+[nitrogen rule](https://en.wikipedia.org/wiki/Nitrogen_rule) and the  [RDBE rule](https://fiehnlab.ucdavis.edu/projects/seven-golden-rules/ring-double-bonds) (Ring Double Bond Equivalent).
 ```{r}
 formula <- get.formula('NH4', charge = 0)
 isvalid.formula(formula,rule=c("nitrogen","RDBE"))

--- a/rcdk/vignettes/using-rcdk.Rmd
+++ b/rcdk/vignettes/using-rcdk.Rmd
@@ -187,8 +187,8 @@ Once you have a depictor object, you can set individual properties using the `$`
 ```{r eval=FALSE}
 depictor <- get.depictor(style='cob', abbr='reagents', width=300, height=300)
 view.molecule.2d(mols[[5]], depictor=depictor)
-depictor$setStyle('cow')
-view.molecule.2d(mols[[5]], depictor=depictor)
+#depictor$setStyle('cow')
+#view.molecule.2d(mols[[5]], depictor=depictor)
 ```
 
 The method also allows you to highlight substructures using [SMARTS](https://en.wikipedia.org/wiki/Smiles_arbitrary_target_specification). This is useful in highlight commen substructures in a set of molecules

--- a/rcdk/vignettes/using-rcdk.Rmd
+++ b/rcdk/vignettes/using-rcdk.Rmd
@@ -138,7 +138,7 @@ unlist(lapply(mols, get.smiles))
  
  The [CDK](https://cdk.github.io) supports a number of _flavors_ when generating SMILES. For example, you can generate a SMILES with or without chirality information or generate SMILES in [Kekule form](https://www.chemguide.co.uk/basicorg/bonding/benzene1.html). The `smiles.flavors` generates an object that represents the various flavors desired for SMILES output. See the [SmiFlavor javadocs](https://cdk.github.io/cdk/2.3/docs/api/index.html?org/openscience/cdk/smiles/SmiFlavor.html) for the full list of possible flavors. Example usage is
  
- ```{r}
+```{r}
 smiles <- c('CCC', 'c1ccccc1', 'CCc1ccccc1CC(C)(C)CC(=O)NC')
 mols <- parse.smiles(smiles)
 get.smiles(mols[[3]], smiles.flavors(c('UseAromaticSymbols')))

--- a/rcdk/vignettes/using-rcdk.Rmd
+++ b/rcdk/vignettes/using-rcdk.Rmd
@@ -369,7 +369,7 @@ When a descriptor value cannot be computed, it's value is set to `NA`. This may 
 
 Given the ubiquity of certain descriptors, some of them are directly available
 via their own functions. Specifically, one can calculate [TPSA](https://www.ncbi.nlm.nih.gov/pubmed/19149561) (topological
-polar surface area), [AlogP](http://pubs.acs.org/doi/abs/10.1021/jp980230o) and [XlogP](http://www.compchemcons.com/xlogp/xlogp.html) without having to go through
+polar surface area), [AlogP](https://pubs.acs.org/doi/abs/10.1021/jp980230o) and [XlogP](http://www.compchemcons.com/xlogp/xlogp.html) without having to go through
 `eval.desc`. (Note that AlogP and XlogP assume that hydrogens are explicitly specified in the molecule. This may not be true if the molecules were obtained from SMILES)
 ```{r}
 mol <- parse.smiles('CC(=O)CC(=O)NCN')[[1]]
@@ -410,7 +410,7 @@ abline(0,1, col='red')
 
 ## Fingerprints
 
-Fingerprints are a common representation used for a variety of purposes such as similarity searching and predictive modeling. The [CDK](https://cdk.github.io/) provides a variety of fingerprints ranging from path-based hashed fingerprints to circular (specifically, an implementation fo the [ECFP](http://pubs.acs.org/doi/abs/10.1021/ci100050t) fingerprints) and signature fingerprints (based on the [signature](http://pubs.acs.org/doi/abs/10.1021/ci020345w) molecular descriptor). Some of the fingerprints are represented as binary strings and other by integer vectors. The `rcdk` employs the [fingerprint](https://CRAN.R-project.org/package=fingerprint) package to support operations on the resultant fingerprints.
+Fingerprints are a common representation used for a variety of purposes such as similarity searching and predictive modeling. The [CDK](https://cdk.github.io/) provides a variety of fingerprints ranging from path-based hashed fingerprints to circular (specifically, an implementation fo the [ECFP](https://pubs.acs.org/doi/abs/10.1021/ci100050t) fingerprints) and signature fingerprints (based on the [signature](https://pubs.acs.org/doi/abs/10.1021/ci020345w) molecular descriptor). Some of the fingerprints are represented as binary strings and other by integer vectors. The `rcdk` employs the [fingerprint](https://CRAN.R-project.org/package=fingerprint) package to support operations on the resultant fingerprints.
 
 In this section, we present an example of using fingerprints to generate a hierarchical clustering of a set of molecules from the included boiling point dataset. We first parse the SMILES for the molecules in the dataset and then compute the fingerprints, specifying the `circular` type.
 ```{r}

--- a/rcdk/vignettes/using-rcdk.Rmd
+++ b/rcdk/vignettes/using-rcdk.Rmd
@@ -145,7 +145,7 @@ get.smiles(mols[[3]], smiles.flavors(c('UseAromaticSymbols')))
 get.smiles(mols[[3]], smiles.flavors(c('Generic','CxSmiles')))
 ```
 
-Using the [CxSmiles](http://www.chemeddl.org/tools/marvin/help/formats/cxsmiles-doc.html) flavors allows the user to encode a variety of information in the SMILES string, such as 2D or 3D coordinates.
+Using the [CxSmiles](http://butane.chem.uiuc.edu/jsmoore/marvin/help/formats/cxsmiles-doc.html) flavors allows the user to encode a variety of information in the SMILES string, such as 2D or 3D coordinates.
 
 ```{r}
 m <- parse.smiles('CCC')[[1]]

--- a/rcdk/vignettes/using-rcdk.Rmd
+++ b/rcdk/vignettes/using-rcdk.Rmd
@@ -368,7 +368,7 @@ dim(descs)
 When a descriptor value cannot be computed, it's value is set to `NA`. This may happen if a descriptor requires 3D coordinates, but only 2D coordinates are available. In this case, we have manually selected descriptors such that there will be no undefined values.
 
 Given the ubiquity of certain descriptors, some of them are directly available
-via their own functions. Specifically, one can calculate [TPSA](https://www.ncbi.nlm.nih.gov/pubmed/19149561) (topological
+via their own functions. Specifically, one can calculate [TPSA](https://pubmed.ncbi.nlm.nih.gov/19149561/) (topological
 polar surface area), [AlogP](https://pubs.acs.org/doi/abs/10.1021/jp980230o) and [XlogP](http://www.compchemcons.com/xlogp/xlogp.html) without having to go through
 `eval.desc`. (Note that AlogP and XlogP assume that hydrogens are explicitly specified in the molecule. This may not be true if the molecules were obtained from SMILES)
 ```{r}


### PR DESCRIPTION
-  Setup testing on JDK17 in GH Actions
-  Identify test failures and fix them.
- Almost all of the issues are tracked to the use of the `J` convenience function for defining Java classes.
- Current tests all pass on my machine