### PR TITLE
Update DESCRIPTION

### DIFF
--- a/rcdk/DESCRIPTION
+++ b/rcdk/DESCRIPTION
@@ -20,7 +20,6 @@ Suggests:
     knitr,
     rmarkdown,
     devtools
-SystemRequirements: Java JDK 8 or higher
 License: LGPL
 LazyLoad: yes
 LazyData: true


### PR DESCRIPTION
Remove the System Requirements for JDK in accordance with new policy. System requirement is pulled in via dependency on the rJava package